### PR TITLE
Fix error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ elvia = Elvia(token)
 async def get_meter_values():
     meter_value_client = elvia.meter_value()
 
-    print(json.dumps(meter_value_client.get_meter_values(
+    print(json.dumps(await meter_value_client.get_meter_values(
         {
             "start_time": "2021-12-08T01:00:00",
             "end_time": "2021-12-08T02:00:00",

--- a/elvia/meter_value.py
+++ b/elvia/meter_value.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from urllib.parse import urlunparse
 import aiohttp
 
+
 class MeterValue:
     """
     Elvia MeterValue client

--- a/elvia/meter_value.py
+++ b/elvia/meter_value.py
@@ -10,7 +10,6 @@ from urllib.parse import urlparse
 from urllib.parse import urlunparse
 import aiohttp
 
-
 class MeterValue:
     """
     Elvia MeterValue client
@@ -59,7 +58,7 @@ class MeterValue:
             }
         ) as websession:
             response = await websession.get(url_string)
-            _verify_response(response, 200)
+            await _verify_response(response, 200)
             return await response.json()
 
     async def get_meter_values(
@@ -94,25 +93,25 @@ class MeterValue:
             }
         ) as websession:
             response = await websession.get(urlunparse(url))
-            _verify_response(response, 200)
+            await _verify_response(response, 200)
             return await response.json()
 
 
-def _verify_response(response, expected_status):
+async def _verify_response(response, expected_status):
     if response.status == 400:
         raise InvalidRequestBody(
             "Body is malformed",
-            status=response.status,
+            status_code=response.status,
             headers=response.headers,
-            body=response.text,
+            body=await response.text(),
         )
 
     if response.status in [401, 403]:
         raise AuthError(
             "Auth failed",
-            status=response.status,
+            status_code=response.status,
             headers=response.headers,
-            body=response.text,
+            body=await response.text(),
         )
 
     if response.status != expected_status:
@@ -120,5 +119,5 @@ def _verify_response(response, expected_status):
             "Received unexpected server response",
             status_code=response.status_code,
             headers=response.headers,
-            body=response.text,
+            body=await response.text(),
         )

--- a/elvia/version.py
+++ b/elvia/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.4"
+VERSION = "0.0.5"


### PR DESCRIPTION
Couldn't print errors because we didn't await `response.text`