### PR TITLE
Change API key header name

### DIFF
--- a/elvia/grid_tariff.py
+++ b/elvia/grid_tariff.py
@@ -61,7 +61,7 @@ class GridTariff:
 
         async with aiohttp.ClientSession(
             headers={
-                "Ocp-Apim-Subscription-Key": self.token,
+                "X-API-Key": self.token,
                 "Content-Type": "application/json",
             }
         ) as websession:
@@ -83,7 +83,7 @@ class GridTariff:
         url_base = f"{self.api_url}/grid-tariff/digin/api/1/tarifftype"
         async with aiohttp.ClientSession(
             headers={
-                "Ocp-Apim-Subscription-Key": self.token,
+                "X-API-Key": self.token,
                 "Content-Type": "application/json",
             }
         ) as websession:
@@ -121,7 +121,7 @@ class GridTariff:
 
         async with aiohttp.ClientSession(
             headers={
-                "Ocp-Apim-Subscription-Key": self.token,
+                "X-API-Key": self.token,
                 "Content-Type": "application/json",
             }
         ) as websession:
@@ -138,7 +138,7 @@ class GridTariff:
         url_base = f"{self.api_url}/grid-tariff/Ping"
         async with aiohttp.ClientSession(
             headers={
-                "Ocp-Apim-Subscription-Key": self.token,
+                "X-API-Key": self.token,
             }
         ) as websession:
             response = await websession.get(url_base)


### PR DESCRIPTION
Change from `Ocp-Apim-Subscription-Key` to `X-API-Key` to conform to new standard.

See https://elvia.mnm.as/r/119324/734637631/11325?l=3Dnb-NO for more information about the change
